### PR TITLE
fix: resolve annotate gem dependency issue for end users

### DIFF
--- a/leva.gemspec
+++ b/leva.gemspec
@@ -23,4 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "importmap-rails", "~> 2.0"
   spec.add_dependency "stimulus-rails", "~> 1.3"
   spec.add_dependency "tailwindcss-rails", "~> 3.0"
+
+  spec.add_development_dependency "annotate"
 end

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -2,8 +2,10 @@
 # NOTE: are sensitive to local FS writes, and besides -- it's just not proper
 # NOTE: to have a dev-mode tool do its thing in production.
 if Rails.env.development?
-  require "annotate"
-  task :set_annotation_options do
+  begin
+    require "annotate"
+    
+    task :set_annotation_options do
     # You can override any of these by setting an environment variable of the
     # same name.
     Annotate.set_defaults(
@@ -55,5 +57,8 @@ if Rails.env.development?
     )
   end
 
-  Annotate.load_tasks
+    Annotate.load_tasks
+  rescue LoadError
+    # annotate gem not available, skipping annotation tasks
+  end
 end


### PR DESCRIPTION
This commit fixes a critical issue where users installing the leva gem would encounter LoadError crashes when running Rails in development mode or executing any rake tasks, if they didn't have the `annotate` gem installed.

Fixed https://github.com/kieranklaassen/leva/issues/17

**Problem:**
- The auto_annotate_models.rake task was unconditionally requiring 'annotate'
- Rails engines automatically load all rake tasks to host applications
- Users without annotate gem would get LoadError during Rails boot or rake execution
- This affected basic operations like 'rails leva:install:migrations'

**Solution:**
1. Add annotate as development dependency in gemspec
   - Ensures leva gem contributors get annotate automatically
   - Follows proper dependency management practices

2. Add defensive LoadError rescue in rake task
   - Gracefully skips annotation tasks if annotate gem unavailable
   - Maintains functionality for users who do have annotate installed
   - Prevents crashes for users who don't need annotation features

The annotate functionality is purely for maintaining leva's own model documentation and provides no runtime value to end users.

Fixes issues with:
- Rails server startup in development
- Running any rake tasks (leva:install:migrations, db:migrate, etc.)
- Basic gem installation and usage