### PR TITLE
docs: add routes mounting instructions to Installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ rails leva:install:migrations
 rails db:migrate
 ```
 
+Mount the Leva engine in your application's routes file:
+
+```ruby
+# config/routes.rb
+Rails.application.routes.draw do
+  mount Leva::Engine => "/leva"
+  # your other routes...
+end
+```
+
+The Leva UI will then be available at `/leva` in your application.
+
 ## Usage
 
 ### 1. Setting up Datasets


### PR DESCRIPTION
The Installation section was missing critical information about how to mount the Leva engine in the host application's routes file. Without this step, users would install the gem and run migrations but not be able to access the Leva UI.

Added instructions to mount the engine at '/leva' path with example code showing proper placement in config/routes.rb.