### PR TITLE
fix: Relax Liquid gem version constraint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ PATH
   remote: .
   specs:
     leva (0.3.3)
-      liquid (~> 5.5.0)
+      liquid (~> 5.5)
       rails (>= 7.2.0)
 
 GEM

--- a/leva.gemspec
+++ b/leva.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "rails", ">= 7.2.0"
-  spec.add_dependency "liquid", "~> 5.5.0"
+  spec.add_dependency "liquid", "~> 5.5"
 end


### PR DESCRIPTION
## Summary
- Relaxes the Liquid gem version constraint from `~> 5.5.0` to `~> 5.5`
- This allows users to use newer Liquid versions (5.6, 5.7, ..., 5.11, etc.) up to but not including 6.0
- The previous constraint was unnecessarily restrictive

Fixes #30

## Testing
- All tests pass
- Rubocop passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)