### PR TITLE
Fix failed experiment message on show page

### DIFF
--- a/app/views/leva/experiments/show.html.erb
+++ b/app/views/leva/experiments/show.html.erb
@@ -167,6 +167,10 @@
           </table>
         </div>
       </div>
+    <% elsif @experiment.failed? %>
+      <div class="empty-state-inline">
+        <p class="text-muted">Experiment failed. Check logs for details.</p>
+      </div>
     <% else %>
       <div class="empty-state-inline">
         <p class="text-muted">No results yet. Run the experiment to see results.</p>

--- a/test/controllers/leva/experiments_controller_test.rb
+++ b/test/controllers/leva/experiments_controller_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Leva
+  class ExperimentsControllerTest < ActionDispatch::IntegrationTest
+    test "show displays failed message when experiment has failed status and no results" do
+      dataset = Dataset.create!(name: "Test Dataset")
+      experiment = Experiment.create!(
+        name: "Failed Experiment",
+        dataset: dataset,
+        runner_class: "SentimentRun",
+        evaluator_classes: [ "SentimentAccuracyEval" ],
+        status: :failed
+      )
+
+      get leva.experiment_path(experiment)
+
+      assert_response :success
+      assert_match(/Experiment failed/, response.body)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Fixed bug where failed experiments showed "No results yet" instead of a failure message
- Added test coverage for the failed experiment state

## Changes
- Updated `app/views/leva/experiments/show.html.erb` to check for failed status and display appropriate message
- Added controller test to verify failed experiments show the correct message

## Test plan
- [x] Run all tests: `bin/rails test`
- [x] Run linting: `bin/rubocop`
- [x] Manually test by visiting a failed experiment page

🤖 Generated with [Claude Code](https://claude.com/claude-code)