### PR TITLE
Add searchable dropdown for model selection

### DIFF
--- a/app/assets/stylesheets/leva/application.css
+++ b/app/assets/stylesheets/leva/application.css
@@ -3234,3 +3234,78 @@ dialog::backdrop {
   color: var(--gray-500);
   margin: 0;
 }
+
+/* ============================================
+   SEARCHABLE SELECT (Pure Stimulus)
+   Custom searchable dropdown matching Leva design
+   ============================================ */
+
+.searchable-select-wrapper {
+  position: relative;
+}
+
+.searchable-select-dropdown {
+  position: absolute;
+  top: calc(100% + var(--space-1));
+  left: 0;
+  right: 0;
+  background: var(--gray-800);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3), 0 2px 4px -1px rgba(0, 0, 0, 0.2);
+  max-height: 300px;
+  overflow-y: auto;
+  z-index: 1000;
+  display: none;
+}
+
+.searchable-select-dropdown.show {
+  display: block;
+}
+
+.searchable-select-option {
+  padding: var(--space-2) var(--space-3);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: background-color 0.15s;
+  font-size: var(--text-base);
+}
+
+.searchable-select-option:hover {
+  background: var(--gray-700);
+}
+
+.searchable-select-option:active {
+  background: var(--accent-500);
+  color: var(--gray-950);
+}
+
+.searchable-select-dropdown .no-results {
+  padding: var(--space-3);
+  color: var(--gray-500);
+  text-align: center;
+  font-size: var(--text-sm);
+}
+
+/* Scrollbar styling for dropdown */
+.searchable-select-dropdown::-webkit-scrollbar {
+  width: 8px;
+}
+
+.searchable-select-dropdown::-webkit-scrollbar-track {
+  background: var(--gray-900);
+  border-radius: var(--radius-sm);
+}
+
+.searchable-select-dropdown::-webkit-scrollbar-thumb {
+  background: var(--gray-600);
+  border-radius: var(--radius-sm);
+}
+
+.searchable-select-dropdown::-webkit-scrollbar-thumb:hover {
+  background: var(--gray-500);
+}
+
+.searchable-select-option.hidden {
+  display: none;
+}

--- a/app/views/leva/experiments/_form.html.erb
+++ b/app/views/leva/experiments/_form.html.erb
@@ -51,13 +51,25 @@
       <p class="form-hint">The runner executes your model logic for each dataset record.</p>
     </div>
 
-    <div class="form-group" id="model-selection-group">
+    <div class="form-group"
+         id="model-selection-group"
+         data-controller="searchable-select"
+         data-searchable-select-options-value="<%= Leva::PromptOptimizer.available_models.map { |m| { id: m.id, name: m.name } }.to_json %>"
+         data-searchable-select-selected-value="<%= @experiment.metadata&.dig("model") || "gemini-2.5-flash" %>">
       <label for="experiment_metadata_model" class="form-label">Model (for LLM runners)</label>
-      <select name="experiment[metadata][model]" id="experiment_metadata_model" class="form-select">
-        <% Leva::PromptOptimizer.available_models.each do |m| %>
-          <option value="<%= m.id %>" <%= 'selected' if @experiment.metadata&.dig("model") == m.id || (@experiment.metadata.blank? && m.id == "gemini-2.5-flash") %>><%= m.name %></option>
-        <% end %>
-      </select>
+      <div class="searchable-select-wrapper">
+        <input type="text"
+               class="form-input"
+               placeholder="Search for a model..."
+               data-searchable-select-target="search"
+               data-action="input->searchable-select#filter focus->searchable-select#showDropdown"
+               autocomplete="off">
+        <div class="searchable-select-dropdown" data-searchable-select-target="dropdown"></div>
+        <input type="hidden"
+               name="experiment[metadata][model]"
+               id="experiment_metadata_model"
+               data-searchable-select-target="hiddenInput">
+      </div>
       <p class="form-hint">The AI model to use when running LLM-based runners like SentimentLlmRun.</p>
     </div>
   </div>
@@ -84,3 +96,87 @@
     <%= form.submit @experiment.persisted? ? "Update Experiment" : "Create & Run Experiment", class: "btn btn-primary" %>
   </div>
 <% end %>
+
+<script>
+  (() => {
+    const application = Stimulus.Application.start()
+
+    application.register("searchable-select", class extends Stimulus.Controller {
+      static targets = ["search", "dropdown", "hiddenInput"]
+      static values = { options: Array, selected: String }
+
+      connect() {
+        this.clickHandler = this.handleClickOutside.bind(this)
+        document.addEventListener("click", this.clickHandler)
+        this.renderOptions()
+        this.setInitialValue()
+      }
+
+      disconnect() {
+        document.removeEventListener("click", this.clickHandler)
+      }
+
+      renderOptions() {
+        this.dropdownTarget.innerHTML = ""
+        this.optionsValue.forEach((option) => {
+          const div = document.createElement("div")
+          div.className = "searchable-select-option"
+          div.dataset.value = option.id
+          div.dataset.label = option.name
+          div.dataset.action = "click->searchable-select#select"
+          div.textContent = option.name
+          this.dropdownTarget.appendChild(div)
+        })
+      }
+
+      setInitialValue() {
+        const selected = this.optionsValue.find((opt) => opt.id === this.selectedValue)
+        if (selected) {
+          this.hiddenInputTarget.value = selected.id
+          this.searchTarget.value = selected.name
+        }
+      }
+
+      filter() {
+        const query = this.searchTarget.value.toLowerCase()
+        const options = this.dropdownTarget.querySelectorAll(".searchable-select-option")
+        let visibleCount = 0
+
+        options.forEach((option) => {
+          const matches = option.textContent.toLowerCase().includes(query)
+          option.classList.toggle("hidden", !matches)
+          if (matches) visibleCount++
+        })
+
+        this.dropdownTarget.querySelector(".no-results")?.remove()
+        if (visibleCount === 0) {
+          const div = document.createElement("div")
+          div.className = "no-results"
+          div.textContent = "No models found"
+          this.dropdownTarget.appendChild(div)
+        }
+      }
+
+      select(event) {
+        const option = event.currentTarget
+        this.hiddenInputTarget.value = option.dataset.value
+        this.searchTarget.value = option.dataset.label
+        this.hideDropdown()
+      }
+
+      showDropdown() {
+        this.dropdownTarget.classList.add("show")
+      }
+
+      hideDropdown() {
+        this.dropdownTarget.classList.remove("show")
+      }
+
+      handleClickOutside(event) {
+        if (!this.element.contains(event.target)) {
+          this.hideDropdown()
+        }
+      }
+    })
+  })()
+</script>


### PR DESCRIPTION
## Problem
The model list (`RubyLLM.models.chat_models`) is very long, making it difficult to find and select models in the experiment form.

## Solution
Implemented search-as-you-type functionality using pure Stimulus (no external libraries).

## Changes
- ✅ Searchable select Stimulus controller
- ✅ Replace static `<select>` with filterable dropdown
- ✅ Custom CSS matching Leva design system
- ✅ Pass model options via Stimulus values API

## Why Inline Script?

The codebase uses **Stimulus via CDN** without a JavaScript bundler (importmap/esbuild/webpack). Controller files in `app/javascript/controllers/` use ES6 `import` statements that **Sprockets cannot process**.

**Current state:**
- ✅ Stimulus loaded from CDN in layout
- ✅ Inline scripts work (see `_prompt_form.html.erb`)
- ❌ Controller files with `import` statements don't load
- ❌ No build system configured

**Options considered:**
1. **Inline script** (chosen) - works immediately, follows existing pattern
2. Controller file - requires adding importmap/esbuild setup
3. External library (Tom Select) - adds dependency

Chose option 1 to maintain consistency with existing code patterns.

## Implementation Details

**Stimulus best practices:**
- Uses `static values` API for data binding
- Uses `static targets` for DOM references
- `createElement()` for XSS-safe rendering (no string interpolation)
- CSS classes instead of inline styles
- Proper cleanup in `disconnect()`

**Features:**
- Search-as-you-type filtering
- Matches Leva warm design system
- Click outside to close
- "No results" message
- Keeps hidden input for form submission

🤖 Generated with Claude Code